### PR TITLE
iOS 13 fix for disappearing decimal button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/ios/CDVDecimalKeyboard.m
+++ b/src/ios/CDVDecimalKeyboard.m
@@ -124,8 +124,8 @@ BOOL isDifferentKeyboardShown=NO;
     NSNumber* value = [info objectForKey:UIKeyboardAnimationDurationUserInfoKey];
     double dValue = [value doubleValue];
 
-    if(dValue <= 0.0){
-        // [self removeDecimalButton];
+    if(dValue < 0.0){
+        [self removeDecimalButton];
         return;
     }
 


### PR DESCRIPTION
In iOS 13, when clicking the Previous and Next buttons above the keyboard, the decimal button can disappear and not come back.  If you select Done, and reopen the keyboard, the decimal button will reappear until the user selects Previous or Next again.  This change fixes this issue, and is from other forks of this plugin.